### PR TITLE
Add NPM publish Github action & small TS type fix

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,22 @@
+name: publish
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 16
+          registry-url: https://registry.npmjs.org/
+          cache: 'yarn'
+      - run: yarn install
+      - run: yarn build
+      - run: npm publish --access public --tag ${{ github.event.release.tag_name }}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/src/Tippy.ts
+++ b/src/Tippy.ts
@@ -43,7 +43,7 @@ export function createTippyComponent(...plugins: TippyProp[]) {
       },
 
       singleton: {
-        type: String as PropType<string | '' | null>,
+        type: String as PropType<boolean | string | '' | null>,
         required: false,
         default: null,
       },


### PR DESCRIPTION
btw patch version 3.1.3 is missing dist files, this Github action should prevent that from happening (I also forget to do so locally)

**Another tip could be adding a `prepublish` script to the `package.json`**